### PR TITLE
Ensure booleans are sent according to Homie spec

### DIFF
--- a/homie/mqtt/paho_mqtt_client.py
+++ b/homie/mqtt/paho_mqtt_client.py
@@ -61,6 +61,9 @@ class PAHO_MQTT_Client (MQTT_Base):
             logger.warning ('MQTT Unable to connect to Broker {}'.format(e))
 
     def publish(self, topic, payload, retain=True, qos=0):
+        if isinstance(payload, bool):
+          # boolean types must be sent as "true" or "false"
+          payload = str(payload).lower()
         MQTT_Base.publish(self,topic,payload,retain,qos)
         self.mqtt_client.publish(topic, payload, retain=retain, qos=qos)
     


### PR DESCRIPTION
Homie specifies booleans should be sent as the string literals "true" or "false"
Paho-mqtt instead sends them as "True" or "False"
This small commit corrects that problem

Fixes #10 